### PR TITLE
Add esm.sh link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 - [serverless-esbuild](https://github.com/floydspace/serverless-esbuild): A Serverless framework plugin to bundle JavaScript and TypeScript using esbuild.
 - [gulp-esbuild](https://github.com/ym-project/gulp-esbuild): A gulp plugin for esbuild bundler
 - [aws-lambda-nodejs-esbuild](https://github.com/floydspace/aws-lambda-nodejs-esbuild): AWS CDK Construct to bundle JavaScript and TypeScript lambdas using esbuild.
+- [esm.sh](https://github.com/postui/esm.sh): A fast, global content delivery network for ES Modules using esbuild.
 
 ## Plugins
 


### PR DESCRIPTION
A fast, global content delivery network for ES Modules. All modules are transformed to ESM by esbuild in NPM.

```js
import React from 'https://esm.sh/react'
```